### PR TITLE
    `gatsby-plugin-stripe-checkout`,

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,6 +76,7 @@ module.exports = {
     `gatsby-plugin-feed`,
     `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-stripe-checkout`,
     {
       resolve: "gatsby-plugin-typography",
       options: {


### PR DESCRIPTION
    `gatsby-plugin-stripe-checkout`, was missing

Installing Stripe Checkout plugin
Gatsby-v1 Stripe Tut Practice and test
https://www.gatsbyjs.org/docs/ecommerce-tutorial/